### PR TITLE
Publish to PyPI from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: "Main"
 on:
   push:
     branches:
-      - main
+      - test-main
   pull_request:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: publish
+on:
+  push:
+    tags:
+      - v**
+  workflow_run:
+    workflows: ["Main"]
+    types:
+      - completed
+jobs:
+  # Only runs on default branch. This job dynamically sets the pyproject.toml
+  # version to a devN version, like 0.1.0-dev123 so that we can publish an
+  # unstable dev release to pypi. To be eligable for a dev release, the version
+  # must have a bare dev pre-release marker, like 0.1.0-dev. (It can have
+  # multiple, like 0.1.0-alpha1-dev.).
+  # It's not run for tagged releases — they use the version as-is.
+  prepare-dev-release:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    name: "Prepare main branch dev release version"
+    runs-on: ubuntu-latest
+    outputs:
+      dev_version: ${{ steps.dev_version.outputs.dev_version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # We need all commits on the default branch to count them (we don't change
+      # actions/checkout depth as that fetches all branches).
+      - name: Fetch all commits on default branch
+        run: git fetch --unshallow
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tools
+        run: pip install poetry
+
+      - name: Set dev release version
+        id: dev_version
+        run: |
+          if python scripts/set_dev_version.py; then
+            dev_version=$(poetry version --short) || exit 1
+            echo "dev_version=${dev_version:?}" >> $GITHUB_OUTPUT
+          fi
+
+  pypi-publish:
+    name: Upload to PyPI
+    needs: ["prepare-dev-release"]
+    # This can run when prepare-dev-release doesn't for tagged releases. For
+    # default branch, this only runs when the commit is eligible for a dev
+    # release, as described above prepare-dev-release.
+    if: ${{ needs.prepare-dev-release.outputs.dev_version != '' || (always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    environment: test-release
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tools
+        run: pip install poetry
+
+      - name: Set dev release version
+        if: needs.prepare-dev-release.outputs.dev_version != ''
+        env:
+          DEV_VERSION: ${{ needs.prepare-dev-release.outputs.dev_version }}
+        run: poetry version "${DEV_VERSION:?}"
+
+      - name: Build the release packages
+        run: |
+          poetry build
+          sha256sum dist/*
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
     # default branch, this only runs when the commit is eligible for a dev
     # release, as described above prepare-dev-release.
     if: ${{ needs.prepare-dev-release.outputs.dev_version != '' || (always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
-    environment: test-release
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
@@ -81,5 +81,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "denokv"
-version = "0.1.0-alpha.dev"
+version = "0.1.0-alpha-dev"
 description = "Connect to Deno KV databases from Python."
 authors = ["Hal Blackburn <hwtb2@cam.ac.uk>"]
 license = "MIT"

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -37,19 +37,10 @@ def main() -> None:
     dev_number_proc.check_returncode()
     dev_number = int(dev_number_proc.stdout.strip())
 
-    short_sha_proc = run(
-        ["git", "rev-parse", "--short", "HEAD"],
-        shell=False,
-        stdout=PIPE,
-        encoding="utf-8",
-    )
-    short_sha_proc.check_returncode()
-    short_sha = short_sha_proc.stdout.strip()
-
     ver_prefix = raw_version[: dev_match.start()]
     ver_suffix = raw_version[dev_match.end() :]
 
-    this_version = f"{ver_prefix}dev{dev_number:d}{ver_suffix}+{short_sha}"
+    this_version = f"{ver_prefix}dev{dev_number:d}{ver_suffix}"
 
     run(["poetry", "version", this_version], shell=False).check_returncode()
 

--- a/scripts/set_dev_version.py
+++ b/scripts/set_dev_version.py
@@ -1,0 +1,58 @@
+"""Set the pyproject.toml version to `-devN` where N is a unique number."""
+
+import re
+import sys
+from subprocess import PIPE
+from subprocess import run
+
+DEV_PATTERN = r"(?<=-)dev(?=$|[+-])"
+
+
+def main() -> None:
+    poetry_version = run(
+        ["poetry", "version", "--short"], shell=False, stdout=PIPE, encoding="utf-8"
+    )
+    poetry_version.check_returncode()
+    raw_version = poetry_version.stdout.strip()
+
+    dev_match = re.search(DEV_PATTERN, raw_version)
+    if not dev_match:
+        print(
+            f"pyproject.toml version is not plain dev version: {raw_version!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if "+" in raw_version:
+        print(
+            f"pyproject.toml version contains a '+' build identifier: {raw_version!r}"
+        )
+        sys.exit(1)
+
+    dev_number_proc = run(
+        ["git", "rev-list", "--count", "HEAD"],
+        shell=False,
+        stdout=PIPE,
+        encoding="utf-8",
+    )
+    dev_number_proc.check_returncode()
+    dev_number = int(dev_number_proc.stdout.strip())
+
+    short_sha_proc = run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        shell=False,
+        stdout=PIPE,
+        encoding="utf-8",
+    )
+    short_sha_proc.check_returncode()
+    short_sha = short_sha_proc.stdout.strip()
+
+    ver_prefix = raw_version[: dev_match.start()]
+    ver_suffix = raw_version[dev_match.end() :]
+
+    this_version = f"{ver_prefix}dev{dev_number:d}{ver_suffix}+{short_sha}"
+
+    run(["poetry", "version", this_version], shell=False).check_returncode()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR implements publishing the denokv package to PyPI, using OIDC trusted publishing, from a GitHub Actions workflow.

Tagged release commits are published, as well as commits on the default (`main`) branch that have a plain `-dev` pre-release version identifier. These dev releases get auto-generated `devNN` version numbers based on the depth of the commit in the main branch's commit chain leading to the commit.