### PR TITLE
Improve KvKey and add types to represent KvKey ranges

### DIFF
--- a/src/denokv/__init__.py
+++ b/src/denokv/__init__.py
@@ -14,9 +14,9 @@ from denokv.kv import CursorFormatType as CursorFormatType
 from denokv.kv import Kv as Kv
 from denokv.kv import KvCredentials as KvCredentials
 from denokv.kv import KvEntry as KvEntry
-from denokv.kv import KvKey as KvKey
 from denokv.kv import KvListOptions as KvListOptions
 from denokv.kv import KvU64 as KvU64
 from denokv.kv import ListKvEntry as ListKvEntry
 from denokv.kv import VersionStamp as VersionStamp
 from denokv.kv import open_kv as open_kv
+from denokv.kv_keys import KvKey as KvKey

--- a/src/denokv/_pycompat/typing.py
+++ b/src/denokv/_pycompat/typing.py
@@ -1,0 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import override as override
+else:
+
+    def override(method, /):
+        return method

--- a/src/denokv/datapath.py
+++ b/src/denokv/datapath.py
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
 
     @runtime_checkable
     class KvKeyEncodable(Protocol):
+        __slots__ = ()
+
         def kv_key_bytes(self) -> bytes: ...
 
     KvKeyEncodableT = TypeVar("KvKeyEncodableT", bound=KvKeyEncodable)

--- a/src/denokv/datapath.py
+++ b/src/denokv/datapath.py
@@ -377,9 +377,16 @@ async def snapshot_read(
     return Ok(read_output)
 
 
-def is_kv_key_tuple(tup: tuple[object, ...]) -> TypeGuard[KvKeyTuple]:
+def is_kv_key_tuple(tup: object) -> TypeGuard[KvKeyTuple]:
     """Check if a tuple only contains valid KV key tuple type values."""
-    return all(isinstance(part, KV_KEY_PIECE_TYPES) for part in tup)
+    return isinstance(tup, tuple) and all(
+        isinstance(part, KV_KEY_PIECE_TYPES) for part in tup
+    )
+
+
+def is_any_kv_key(obj: object) -> TypeGuard[AnyKvKey]:
+    """Check if an object is an AnyKvKey type."""
+    return isinstance(obj, KvKeyEncodable) or is_kv_key_tuple(obj)
 
 
 def parse_protobuf_kv_entry(

--- a/src/denokv/datapath.py
+++ b/src/denokv/datapath.py
@@ -459,6 +459,10 @@ def parse_protobuf_kv_entry(
     return Ok((key, value, raw.versionstamp))
 
 
+_PACK_KEY_CACHE_LIMIT = 128
+_PACK_KEY_CACHE: dict[tuple[tuple[type[KvKeyPiece], ...], KvKeyTuple], bytes] = {}
+
+
 def pack_key(key: AnyKvKey) -> bytes:
     r"""
     Encode a KV key tuple into its bytes form, enforcing type restrictions.
@@ -482,12 +486,24 @@ def pack_key(key: AnyKvKey) -> bytes:
     """  # noqa: E501
     if isinstance(key, KvKeyEncodable):
         return key.kv_key_bytes()
-    if not all(isinstance(piece, KV_KEY_PIECE_TYPES) for piece in key):
-        raise TypeError(
-            f"key contains types other than "
-            f"{', '.join(t.__name__ for t in KV_KEY_PIECE_TYPES)}: {key!r}"
-        )
-    return pack(key)
+
+    cache = _PACK_KEY_CACHE
+    cache_key = tuple([type(x) for x in key]), tuple(key)
+    packed_key = cache.get(cache_key)
+    if packed_key:
+        return packed_key
+
+    for piece in key:
+        if not isinstance(piece, KV_KEY_PIECE_TYPES):
+            raise TypeError(
+                f"key contains types other than "
+                f"{', '.join(t.__name__ for t in KV_KEY_PIECE_TYPES)}: {key!r}"
+            )
+    packed_key = pack(key)
+    if len(cache) >= _PACK_KEY_CACHE_LIMIT:
+        del cache[next(iter(cache.keys()))]
+    cache[cache_key] = packed_key
+    return packed_key
 
 
 class PackKeyRangeOptions(TypedDict, total=False):

--- a/src/denokv/datapath.py
+++ b/src/denokv/datapath.py
@@ -530,9 +530,16 @@ def pack_key_range(
     only be used to evaluate start/end of range queries, not as actual key
     values.
     """
-    packed_start = pack_key(start) if start is not None else pack_key(prefix or ())
+    packed_prefix: bytes | None = None
+    packed_start = (
+        pack_key(start)
+        if start is not None
+        else (packed_prefix := pack_key(prefix or ()))
+    )
     packed_end = (
-        pack_key(end) if end is not None else (pack_key(prefix or ()) + b"\xff")
+        (packed_start if start is end else pack_key(end))
+        if end is not None
+        else ((packed_prefix or pack_key(prefix or ())) + b"\xff")
     )
     # The datapath protocol includes the start, so if we want to exclude it we
     # need to increment the start key to start from the next key after it.

--- a/src/denokv/datapath.py
+++ b/src/denokv/datapath.py
@@ -12,8 +12,11 @@ from enum import auto
 from typing import TYPE_CHECKING
 from typing import Awaitable
 from typing import Callable
+from typing import Container
 from typing import Final
 from typing import Protocol
+from typing import TypedDict
+from typing import overload
 from typing import runtime_checkable
 
 import aiohttp
@@ -44,6 +47,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
     from typing_extensions import TypeGuard
     from typing_extensions import TypeVar
+    from typing_extensions import Unpack
 
     KvKeyPiece: TypeAlias = "str | bytes | int | float | bool"
     KvKeyPieceT = TypeVar("KvKeyPieceT", bound=KvKeyPiece, default=KvKeyPiece)
@@ -61,6 +65,9 @@ if TYPE_CHECKING:
     KvKeyEncodableT = TypeVar("KvKeyEncodableT", bound=KvKeyEncodable)
     AnyKvKey: TypeAlias = "KvKeyEncodable | KvKeyTuple"
     AnyKvKeyT = TypeVar("AnyKvKeyT", bound=AnyKvKey, default=AnyKvKey)
+    AnyKvKeyT_co = TypeVar(
+        "AnyKvKeyT_co", bound=AnyKvKey, default=AnyKvKey, covariant=True
+    )
     AnyKvKeyT_con = TypeVar(
         "AnyKvKeyT_con", bound=AnyKvKey, default=AnyKvKey, contravariant=True
     )
@@ -81,9 +88,16 @@ else:
     KvKeyEncodableT = TypeVar("KvKeyEncodableT", bound=KvKeyEncodable)
     AnyKvKey: TypeAlias = "KvKeyEncodable | KvKeyTuple"
     AnyKvKeyT = TypeVar("AnyKvKeyT", bound=AnyKvKey)
+    AnyKvKeyT_co = TypeVar("AnyKvKeyT", bound=AnyKvKey, covariant=True)
     AnyKvKeyT_con = TypeVar("AnyKvKeyT_con", bound=AnyKvKey, contravariant=True)
 
 _T = TypeVar("_T")
+
+
+@runtime_checkable
+class KvKeyRangeEncodable(Container[AnyKvKey], Protocol):
+    def kv_key_range_bytes(self) -> tuple[bytes, bytes]: ...
+
 
 _LE64 = struct.Struct("<Q")
 """Little-endian 64-bit unsigned int format."""
@@ -474,7 +488,26 @@ def pack_key(key: AnyKvKey) -> bytes:
     return pack(key)
 
 
+class PackKeyRangeOptions(TypedDict, total=False):
+    """Keyword arguments of `pack_key_range()`."""
+
+    prefix: AnyKvKey | None
+    start: AnyKvKey | None
+    end: AnyKvKey | None
+    exclude_start: bool
+    exclude_end: bool
+
+
+@overload
+def pack_key_range(key_range: KvKeyRangeEncodable) -> tuple[bytes, bytes]: ...
+
+
+@overload
+def pack_key_range(**options: Unpack[PackKeyRangeOptions]) -> tuple[bytes, bytes]: ...
+
+
 def pack_key_range(
+    key_range: KvKeyRangeEncodable | None = None,
     *,
     prefix: AnyKvKey | None = None,
     start: AnyKvKey | None = None,
@@ -537,6 +570,9 @@ def pack_key_range(
     only be used to evaluate start/end of range queries, not as actual key
     values.
     """
+    if key_range is not None:
+        return key_range.kv_key_range_bytes()
+
     packed_prefix: bytes | None = None
     packed_start = (
         pack_key(start)

--- a/src/denokv/kv.py
+++ b/src/denokv/kv.py
@@ -23,7 +23,6 @@ from typing import TypedDict
 from typing import overload
 
 import aiohttp
-from fdb.tuple import pack
 from fdb.tuple import unpack
 from v8serialize import Decoder
 from yarl import URL
@@ -42,13 +41,11 @@ from denokv.auth import get_database_metadata
 from denokv.backoff import Backoff
 from denokv.backoff import ExponentialBackoff
 from denokv.backoff import attempts
-from denokv.datapath import KV_KEY_PIECE_TYPES
 from denokv.datapath import AnyKvKey
 from denokv.datapath import AnyKvKeyT
 from denokv.datapath import AutoRetry
 from denokv.datapath import DataPathError
 from denokv.datapath import KvKeyEncodable
-from denokv.datapath import KvKeyEncodableT
 from denokv.datapath import KvKeyPiece
 from denokv.datapath import KvKeyTuple
 from denokv.datapath import ProtocolViolation
@@ -59,6 +56,7 @@ from denokv.datapath import parse_protobuf_kv_entry
 from denokv.datapath import read_range_multi
 from denokv.datapath import read_range_single
 from denokv.errors import InvalidCursor
+from denokv.kv_keys import KvKey
 from denokv.result import Err
 from denokv.result import Ok
 from denokv.result import Result
@@ -239,81 +237,6 @@ class KvU64:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.value})"
-
-
-class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
-    """
-    A key identifying a value in a Deno KV database.
-
-    KvKey is a tuple of key pieces — str, bytes, int, float or bool. Unlike a
-    plain tuple, KvKey's values are guaranteed to only be valid key values, and
-    int values are not coerced to float for JavaScript comparability when used
-    with [Kv] methods.
-
-    [Kv]: `denokv.kv.Kv`
-    """
-
-    # The Pieces TypeVarTuple cannot be bounded to KvKeyPiece elements, so this
-    # type can hold any element, but  only KvKeyPiece can exist at runtime.
-    def __new__(cls, *pieces: Unpack[Pieces]) -> KvKey[Unpack[Pieces]]:
-        if not is_kv_key_tuple(pieces):
-            raise TypeError(
-                f"key contains types other than "
-                f"{', '.join(t.__name__ for t in KV_KEY_PIECE_TYPES)}: {pieces!r}"
-            )
-        return tuple.__new__(KvKey, pieces)
-
-    @overload
-    @classmethod
-    def wrap_tuple_keys(cls, key: KvKeyTuple) -> DefaultKvKey: ...
-
-    @overload
-    @classmethod
-    def wrap_tuple_keys(cls, key: KvKeyEncodableT) -> KvKeyEncodableT: ...
-
-    @classmethod
-    def wrap_tuple_keys(
-        cls, key: KvKeyTuple | KvKeyEncodableT
-    ) -> DefaultKvKey | KvKeyEncodableT:
-        """
-        Return simple tuples as KvKey but return [KvKeyEncodable] keys as-is.
-
-        Notes
-        -----
-        By wrapping plain tuple keys as KvKey we preserve int as int if a key
-        read from the DB is passed back into a Kv method which is normalising int
-        to float for JS compatibility.
-        """
-        if isinstance(key, KvKeyEncodable):
-            return key  # type: ignore[return-value,unused-ignore]
-        return cls(*key)  # type: ignore[arg-type,return-value,unused-ignore]
-
-    def kv_key_bytes(self) -> bytes:
-        return pack(self)  # type: ignore[arg-type]
-
-    @classmethod
-    def from_kv_key_bytes(cls, packed_key: bytes) -> DefaultKvKey:
-        """Create a KvKey by unpacking a packed key."""
-        try:
-            # If packed key contains types other than allowed by KvKeyPiece
-            # then the constructor throws TypeError, so this is type-safe.
-            return cls(*unpack(packed_key))  # type: ignore[arg-type,return-value,unused-ignore]
-        except ValueError as e:
-            raise ValueError(
-                f"Cannot create {cls.__name__} from packed key: {packed_key!r}:"
-                f" value is not a valid packed key"
-            ) from e
-        except TypeError as e:
-            raise ValueError(
-                f"Cannot create {cls.__name__} from packed key: {packed_key!r}: {e}"
-            ) from e
-
-
-# Ideally the default parameter of the Pieces KvKeyTuple would make this the
-# default for KvKey (with no generic type), but mypy thinks it is
-# KvKey[*tuple[Any, ...]] when used without generic type args.
-DefaultKvKey: TypeAlias = "KvKey[Unpack[tuple[KvKeyPiece, ...]]]"
-"""KvKey containing any number of key values of any allowed type."""
 
 
 @dataclass(frozen=True, **slots_if310())

--- a/src/denokv/kv_keys.py
+++ b/src/denokv/kv_keys.py
@@ -239,7 +239,7 @@ else:
         [Kv]: `denokv.kv.Kv`
         """
 
-        __slots__ = ()
+        __slots__ = ("__weakref__",)
 
         def __len__(self) -> int:
             return len(self._unpacked)

--- a/src/denokv/kv_keys.py
+++ b/src/denokv/kv_keys.py
@@ -1,19 +1,40 @@
 from __future__ import annotations
 
+import functools
+from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Final
+from typing import Generic
+from typing import Union
+from typing import cast
 from typing import overload
 
 from fdb.tuple import pack
 from fdb.tuple import unpack
 
+from denokv._pycompat.dataclasses import slots_if310
+from denokv._pycompat.typing import override
 from denokv.datapath import KV_KEY_PIECE_TYPES
+from denokv.datapath import AnyKvKey
+from denokv.datapath import AnyKvKeyT
+from denokv.datapath import AnyKvKeyT_co
 from denokv.datapath import KvKeyEncodable
 from denokv.datapath import KvKeyEncodableT
 from denokv.datapath import KvKeyPiece
+from denokv.datapath import KvKeyRangeEncodable
 from denokv.datapath import KvKeyTuple
+from denokv.datapath import PackKeyRangeOptions
+from denokv.datapath import is_any_kv_key
 from denokv.datapath import is_kv_key_tuple
+from denokv.datapath import pack_key
+from denokv.datapath import pack_key_range
+from denokv.result import Nothing
+from denokv.result import Some
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
     from typing_extensions import TypeAlias
     from typing_extensions import TypeVar
     from typing_extensions import TypeVarTuple
@@ -98,9 +119,286 @@ class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
                 f"Cannot create {cls.__name__} from packed key: {packed_key!r}: {e}"
             ) from e
 
+    def range_start(self, start: StartT) -> KvKeyRange[StartT, Exclude[Self]]:
+        """Get a key range from a `start` boundary up to but excluding this key."""
+        return KvKeyRange(start, Exclude(self))
+
+    def range_stop(self, stop: StopT) -> KvKeyRange[Include[Self], StopT]:
+        """Get a key range starting with this key up to the `stop` boundary."""
+        return KvKeyRange(Include(self), stop)
+
+    def range(self) -> KvKeyRange[Include[Self], IncludePrefix[Self]]:
+        """Get a key range starting with this key, including all suffixes of it."""
+        return KvKeyRange(Include(self), IncludePrefix(self))
+
 
 # Ideally the default parameter of the Pieces KvKeyTuple would make this the
 # default for KvKey (with no generic type), but mypy thinks it is
 # KvKey[*tuple[Any, ...]] when used without generic type args.
 DefaultKvKey: TypeAlias = "KvKey[Unpack[tuple[KvKeyPiece, ...]]]"
 """KvKey containing any number of key values of any allowed type."""
+
+
+@dataclass(frozen=True, **slots_if310())
+class _KeyBoundary(Generic[AnyKvKeyT_co]):
+    key: Final[AnyKvKeyT_co]  # type: ignore[misc]
+
+    @overload
+    def __init__(self: _KeyBoundary[AnyKvKeyT_co], key: AnyKvKeyT_co) -> None: ...
+
+    @overload
+    def __init__(
+        self: _KeyBoundary[KvKey[Unpack[Pieces]]], *pieces: Unpack[Pieces]
+    ) -> None: ...
+
+    def __init__(self, arg1: AnyKvKeyT_co | KvKeyPiece, *rest: KvKeyPiece) -> None:  # type: ignore[misc]
+        key: AnyKvKey
+        if is_any_kv_key(arg1):
+            key = arg1
+        else:
+            key = KvKey(cast(KvKeyPiece, arg1), *rest)
+        object.__setattr__(self, "key", key)
+
+    @property
+    def key_option(self) -> Some[AnyKvKeyT_co]:
+        return Some(self.key)
+
+    def range_start(self, start: StartT) -> KvKeyRange[StartT, Self]:  # type: ignore[type-var,unused-ignore]  # type-var because Self is not allowed to be the StopT type (but works anyway). unused-ignore because 3.9 does not detect the Self error.
+        return KvKeyRange(start, self)  # type: ignore[type-var,unused-ignore]
+
+    def range_stop(self, stop: StopT) -> KvKeyRange[Self, StopT]:  # type: ignore[type-var,unused-ignore]
+        return KvKeyRange(self, stop)  # type: ignore[type-var,unused-ignore]
+
+    def __repr__(self) -> str:
+        if isinstance(self.key, KvKey):
+            key = tuple.__repr__(self.key)[1:-1]
+        else:
+            key = repr(self.key)
+        return f"{type(self).__name__}({key})"
+
+
+class Include(_KeyBoundary[AnyKvKeyT_co]):
+    """KvKeyRange boundary that includes its key in the range."""
+
+    if TYPE_CHECKING:
+        # For some reason mypy only infers types of Pieces using new not init
+        @overload
+        def __new__(cls, key: AnyKvKeyT, /) -> Include[AnyKvKeyT]: ...  # type: ignore[overload-overlap]
+
+        @overload
+        def __new__(cls, *pieces: Unpack[Pieces]) -> Include[KvKey[Unpack[Pieces]]]: ...
+
+        def __new__(cls, *args: Any) -> Self: ...  # type: ignore[misc]
+
+    def range(self) -> KvKeyRange[Self, Self]:
+        """Get a key range including only this Include's key."""
+        return KvKeyRange(self, self)
+
+
+class IncludePrefix(_KeyBoundary[AnyKvKeyT_co]):
+    """KvKeyRange boundary that includes keys prefixed by its key in the range."""
+
+    if TYPE_CHECKING:
+        # For some reason mypy only infers types of Pieces using new not init
+        @overload
+        def __new__(cls, key: AnyKvKeyT, /) -> IncludePrefix[AnyKvKeyT]: ...  # type: ignore[overload-overlap]
+
+        @overload
+        def __new__(
+            cls, *pieces: Unpack[Pieces]
+        ) -> IncludePrefix[KvKey[Unpack[Pieces]]]: ...
+
+        def __new__(cls, *args: Any) -> Self: ...  # type: ignore[misc]
+
+    @override
+    def range_stop(self, stop: StopT) -> KvKeyRange[Include[AnyKvKeyT_co], StopT]:  # type: ignore[override]
+        return KvKeyRange(Include(self.key), stop)
+
+    def range(self) -> KvKeyRange[Include[AnyKvKeyT_co], Self]:
+        """
+        Create a key range that includes all child keys of this object's key.
+
+        Examples
+        --------
+        >>> r = IncludePrefix('a', 1).range()
+        >>> r
+        KvKeyRange(start=Include('a', 1), stop=IncludePrefix('a', 1))
+        >>> assert ('a', 0, 99) not in r
+        >>> assert ('a', 1) in r
+        >>> assert ('a', 1, 0) in r
+        >>> assert ('a', 1, 99) in r
+        >>> assert ('a', 2, 0) not in r
+        """
+        return KvKeyRange(Include(self.key), self)
+
+
+class Exclude(_KeyBoundary[AnyKvKeyT_co]):
+    """KvKeyRange boundary that excludes its key from the range."""
+
+    if TYPE_CHECKING:
+        # For some reason mypy only infers types of Pieces using new not init
+        @overload
+        def __new__(cls, key: AnyKvKeyT, /) -> Exclude[AnyKvKeyT]: ...  # type: ignore[overload-overlap]
+
+        @overload
+        def __new__(cls, *pieces: Unpack[Pieces]) -> Exclude[KvKey[Unpack[Pieces]]]: ...
+
+        def __new__(cls, *args: Any) -> Self: ...  # type: ignore[misc]
+
+    def range(self) -> KvKeyRange[Self, Self]:
+        """Get an empty key range that excludes this Exclude's key at the boundaries."""
+        return KvKeyRange(self, self)
+
+
+@dataclass(frozen=True, **slots_if310())
+class IncludeAll:
+    """KvKeyRange boundary that includes any key in the range."""
+
+    def __new__(cls) -> Self:
+        # Always return the same unique instance from IncludeAll()
+        instance = object.__new__(cls)
+
+        def __new__(cls: type[IncludeAll]) -> IncludeAll:
+            return instance
+
+        cls.__new__ = __new__  # type: ignore[method-assign,assignment]
+        return instance
+
+    @property
+    def key_option(self) -> Nothing:
+        return Nothing()
+
+    def range_start(self, start: StartT) -> KvKeyRange[StartT, Self]:
+        return KvKeyRange(start, self)
+
+    def range_stop(self, stop: StopT) -> KvKeyRange[Self, StopT]:
+        return KvKeyRange(self, stop)
+
+    @classmethod
+    def range(cls) -> KvKeyRange[IncludeAll, IncludeAll]:
+        """Get a key range that includes all keys."""
+        return KvKeyRange(IncludeAll(), IncludeAll())
+
+
+StartBoundary: TypeAlias = Union[
+    IncludeAll, Include[AnyKvKeyT_co], Exclude[AnyKvKeyT_co]
+]
+StopBoundary: TypeAlias = Union[
+    IncludeAll, Include[AnyKvKeyT], IncludePrefix[AnyKvKeyT], Exclude[AnyKvKeyT]
+]
+
+if TYPE_CHECKING:
+    StartT = TypeVar(
+        "StartT", bound=StartBoundary, default=StartBoundary, covariant=False
+    )
+    StartT_co = TypeVar(
+        "StartT_co", bound=StartBoundary, default=StartBoundary, covariant=True
+    )
+    StopT = TypeVar("StopT", bound=StopBoundary, default=StopBoundary, covariant=False)
+    StopT_co = TypeVar(
+        "StopT_co", bound=StopBoundary, default=StopBoundary, covariant=True
+    )
+else:
+    StartT = TypeVar("StartT", bound=StartBoundary, covariant=False)
+    StopT = TypeVar("StopT", bound=StopBoundary, covariant=False)
+    StartT_co = TypeVar("StartT_co", bound=StartBoundary, covariant=True)
+    StopT_co = TypeVar("StopT_co", bound=StopBoundary, covariant=True)
+
+
+@functools.total_ordering
+@dataclass(frozen=True, eq=False, **slots_if310())
+class KvKeyRange(KvKeyRangeEncodable, Generic[StartT_co, StopT_co]):
+    """
+    A range of KV key values, bounded by a start and end positions.
+
+    Examples
+    --------
+    >>> key_range = Include('a', 0).range_stop(Exclude('a', 10))
+    >>> key_range
+    KvKeyRange(start=Include('a', 0), stop=Exclude('a', 10))
+    >>> KvKey('a', 0) in key_range
+    True
+    >>> KvKey('a', 10) in key_range
+    False
+    >>> KvKey('a', 10) in key_range.range_stop(Include('a', 10))
+    True
+    """
+
+    start: Final[StartT_co] = field(default=cast(StartT_co, IncludeAll()))  # type: ignore[misc]
+    stop: Final[StopT_co] = field(default=cast(StopT_co, IncludeAll()))  # type: ignore[misc]
+    _packed: tuple[bytes, bytes] | None = field(
+        default=None, init=False, repr=False, hash=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        # Types don't allow IncludePrefix as start because it has the same
+        # effect as Include at the start position. But if it is used, we
+        # normalise it.
+        if isinstance(self.start, IncludePrefix):
+            object.__setattr__(self, "start", Include(self.start.key))
+
+        if not isinstance(self.start, (IncludeAll, Include, Exclude)):
+            raise TypeError("start must be IncludeAll, Include or Exclude")
+        if not isinstance(self.stop, (IncludeAll, Include, IncludePrefix, Exclude)):
+            raise TypeError(
+                "stop must be IncludeAll, Include, IncludePrefix or Exclude"
+            )
+
+    def range_start(self, start: StartT) -> KvKeyRange[StartT, StopT_co]:
+        """Get a key range with this range's stop and the provided `start`."""
+        return KvKeyRange(start, self.stop)
+
+    def range_stop(self, stop: StopT) -> KvKeyRange[StartT_co, StopT]:
+        """Get a key range with this range's start and the provided `stop`."""
+        return KvKeyRange(self.start, stop)
+
+    @override
+    def kv_key_range_bytes(self) -> tuple[bytes, bytes]:
+        if (packed := self._packed) is not None:
+            return packed
+
+        options = PackKeyRangeOptions()
+
+        start = self.start
+        if isinstance(start, Include):
+            options["start"] = start.key
+        elif isinstance(start, Exclude):
+            options["start"] = start.key
+            options["exclude_start"] = True
+        else:
+            assert isinstance(start, IncludeAll)
+            options["start"] = ()
+
+        stop = self.stop
+        if isinstance(stop, Include):
+            options["end"] = stop.key
+            options["exclude_end"] = False
+        elif isinstance(stop, Exclude):
+            options["end"] = stop.key
+        elif isinstance(stop, IncludePrefix):
+            options["prefix"] = stop.key
+        else:
+            assert isinstance(stop, IncludeAll)
+
+        object.__setattr__(self, "_packed", (packed := pack_key_range(**options)))
+        return packed
+
+    def __contains__(self, x: object, /) -> bool:
+        if not is_any_kv_key(x):
+            return False
+        packed = pack_key(x)
+        packed_start, packed_stop = pack_key_range(self)
+        return packed_start <= packed < packed_stop
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, KvKeyRange):
+            return NotImplemented
+        return self.kv_key_range_bytes() == value.kv_key_range_bytes()
+
+    def __hash__(self) -> int:
+        return hash(self.kv_key_range_bytes())
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, KvKeyRange):
+            return NotImplemented
+        return self.kv_key_range_bytes() < other.kv_key_range_bytes()

--- a/src/denokv/kv_keys.py
+++ b/src/denokv/kv_keys.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import overload
+
+from fdb.tuple import pack
+from fdb.tuple import unpack
+
+from denokv.datapath import KV_KEY_PIECE_TYPES
+from denokv.datapath import KvKeyEncodable
+from denokv.datapath import KvKeyEncodableT
+from denokv.datapath import KvKeyPiece
+from denokv.datapath import KvKeyTuple
+from denokv.datapath import is_kv_key_tuple
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+    from typing_extensions import TypeVar
+    from typing_extensions import TypeVarTuple
+    from typing_extensions import Unpack
+
+    T = TypeVar("T", default=object)
+    # Note that the default arg doesn't seem to work with MyPy yet. The
+    # DefaultKvKey alias is what this should behave as when defaulted.
+    Pieces = TypeVarTuple("Pieces", default=Unpack[tuple[KvKeyPiece, ...]])
+else:
+    from typing import TypeVar
+
+    T = TypeVar("T")
+    Unpack = tuple  # hack to support py39 at runtime w/o typing_extensions
+    Pieces = TypeVar("Pieces")  # hack to support py39 at runtime w/o typing_extensions
+
+
+class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
+    """
+    A key identifying a value in a Deno KV database.
+
+    KvKey is a tuple of key pieces — str, bytes, int, float or bool. Unlike a
+    plain tuple, KvKey's values are guaranteed to only be valid key values, and
+    int values are not coerced to float for JavaScript comparability when used
+    with [Kv] methods.
+
+    [Kv]: `denokv.kv.Kv`
+    """
+
+    # The Pieces TypeVarTuple cannot be bounded to KvKeyPiece elements, so this
+    # type can hold any element, but  only KvKeyPiece can exist at runtime.
+    def __new__(cls, *pieces: Unpack[Pieces]) -> KvKey[Unpack[Pieces]]:
+        if not is_kv_key_tuple(pieces):
+            raise TypeError(
+                f"key contains types other than "
+                f"{', '.join(t.__name__ for t in KV_KEY_PIECE_TYPES)}: {pieces!r}"
+            )
+        return tuple.__new__(KvKey, pieces)
+
+    @overload
+    @classmethod
+    def wrap_tuple_keys(cls, key: KvKeyTuple) -> DefaultKvKey: ...
+
+    @overload
+    @classmethod
+    def wrap_tuple_keys(cls, key: KvKeyEncodableT) -> KvKeyEncodableT: ...
+
+    @classmethod
+    def wrap_tuple_keys(
+        cls, key: KvKeyTuple | KvKeyEncodableT
+    ) -> DefaultKvKey | KvKeyEncodableT:
+        """
+        Return simple tuples as KvKey but return [KvKeyEncodable] keys as-is.
+
+        Notes
+        -----
+        By wrapping plain tuple keys as KvKey we preserve int as int if a key
+        read from the DB is passed back into a Kv method which is normalising int
+        to float for JS compatibility.
+        """
+        if isinstance(key, KvKeyEncodable):
+            return key  # type: ignore[return-value,unused-ignore]
+        return cls(*key)  # type: ignore[arg-type,return-value,unused-ignore]
+
+    def kv_key_bytes(self) -> bytes:
+        return pack(self)  # type: ignore[arg-type]
+
+    @classmethod
+    def from_kv_key_bytes(cls, packed_key: bytes) -> DefaultKvKey:
+        """Create a KvKey by unpacking a packed key."""
+        try:
+            # If packed key contains types other than allowed by KvKeyPiece
+            # then the constructor throws TypeError, so this is type-safe.
+            return cls(*unpack(packed_key))  # type: ignore[arg-type,return-value,unused-ignore]
+        except ValueError as e:
+            raise ValueError(
+                f"Cannot create {cls.__name__} from packed key: {packed_key!r}:"
+                f" value is not a valid packed key"
+            ) from e
+        except TypeError as e:
+            raise ValueError(
+                f"Cannot create {cls.__name__} from packed key: {packed_key!r}: {e}"
+            ) from e
+
+
+# Ideally the default parameter of the Pieces KvKeyTuple would make this the
+# default for KvKey (with no generic type), but mypy thinks it is
+# KvKey[*tuple[Any, ...]] when used without generic type args.
+DefaultKvKey: TypeAlias = "KvKey[Unpack[tuple[KvKeyPiece, ...]]]"
+"""KvKey containing any number of key values of any allowed type."""

--- a/src/denokv/kv_keys.py
+++ b/src/denokv/kv_keys.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import functools
+import sys
 from dataclasses import dataclass
 from dataclasses import field
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Final
 from typing import Generic
+from typing import Iterator
+from typing import Sequence
 from typing import Union
 from typing import cast
 from typing import overload
@@ -35,6 +38,7 @@ from denokv.result import Some
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+    from typing_extensions import SupportsIndex
     from typing_extensions import TypeAlias
     from typing_extensions import TypeVar
     from typing_extensions import TypeVarTuple
@@ -51,28 +55,37 @@ else:
     Unpack = tuple  # hack to support py39 at runtime w/o typing_extensions
     Pieces = TypeVar("Pieces")  # hack to support py39 at runtime w/o typing_extensions
 
+_T_co = TypeVar("_T_co", covariant=True)
 
-class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
-    """
-    A key identifying a value in a Deno KV database.
 
-    KvKey is a tuple of key pieces — str, bytes, int, float or bool. Unlike a
-    plain tuple, KvKey's values are guaranteed to only be valid key values, and
-    int values are not coerced to float for JavaScript comparability when used
-    with [Kv] methods.
+class _KvKeyState:
+    _unpacked: KvKeyTuple
+    _packed: bytes | None
+    __slots__ = ("_unpacked", "_packed")
 
-    [Kv]: `denokv.kv.Kv`
-    """
-
-    # The Pieces TypeVarTuple cannot be bounded to KvKeyPiece elements, so this
-    # type can hold any element, but  only KvKeyPiece can exist at runtime.
-    def __new__(cls, *pieces: Unpack[Pieces]) -> KvKey[Unpack[Pieces]]:
+    def __init__(self, *pieces: KvKeyPiece) -> None:
+        self._unpacked = pieces
         if not is_kv_key_tuple(pieces):
             raise TypeError(
                 f"key contains types other than "
                 f"{', '.join(t.__name__ for t in KV_KEY_PIECE_TYPES)}: {pieces!r}"
             )
-        return tuple.__new__(KvKey, pieces)
+        self._packed = None
+
+    def __eq__(self, value: object) -> bool:
+        # We don't compare equal to plain key tuples, because the comparison
+        # is not symmetric and tuple's hash does not follow this equality.
+        if not isinstance(value, KvKeyEncodable):
+            return NotImplemented
+        # unpacked tuples don't compare correctly because python == and hash
+        # treats int and integer floats as the same, but FDB keys don't.
+        return self.kv_key_bytes() == pack_key(value)
+
+    def __hash__(self) -> int:
+        return hash((KvKeyEncodable, self.kv_key_bytes()))
+
+    def __repr__(self) -> str:
+        return f"KvKey{self._unpacked!r}"
 
     @overload
     @classmethod
@@ -100,7 +113,9 @@ class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
         return cls(*key)  # type: ignore[arg-type,return-value,unused-ignore]
 
     def kv_key_bytes(self) -> bytes:
-        return pack(self)  # type: ignore[arg-type]
+        if (packed := self._packed) is None:
+            self._packed = packed = pack(self._unpacked)
+        return packed
 
     @classmethod
     def from_kv_key_bytes(cls, packed_key: bytes) -> DefaultKvKey:
@@ -108,7 +123,7 @@ class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
         try:
             # If packed key contains types other than allowed by KvKeyPiece
             # then the constructor throws TypeError, so this is type-safe.
-            return cls(*unpack(packed_key))  # type: ignore[arg-type,return-value,unused-ignore]
+            kvkey = cls(*unpack(packed_key))  # type: ignore[arg-type]
         except ValueError as e:
             raise ValueError(
                 f"Cannot create {cls.__name__} from packed key: {packed_key!r}:"
@@ -118,6 +133,8 @@ class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
             raise ValueError(
                 f"Cannot create {cls.__name__} from packed key: {packed_key!r}: {e}"
             ) from e
+        kvkey._packed = packed_key  # pre-cache the packed representation
+        return kvkey  # type: ignore[return-value]
 
     def range_start(self, start: StartT) -> KvKeyRange[StartT, Exclude[Self]]:
         """Get a key range from a `start` boundary up to but excluding this key."""
@@ -130,6 +147,147 @@ class KvKey(KvKeyEncodable, tuple[Unpack[Pieces]]):
     def range(self) -> KvKeyRange[Include[Self], IncludePrefix[Self]]:
         """Get a key range starting with this key, including all suffixes of it."""
         return KvKeyRange(Include(self), IncludePrefix(self))
+
+    def include(self) -> Include[Self]:
+        """Get this key as an inclusive key range boundary."""
+        return Include(self)
+
+    def include_prefix(self) -> IncludePrefix[Self]:
+        """Get this key as an inclusive prefix key range boundary."""
+        return IncludePrefix(self)
+
+    def exclude(self) -> Exclude[Self]:
+        """Get this key as an exclusive key range boundary."""
+        return Exclude(self)
+
+    # Methods supported by tuple that we handle slightly differently
+    def __lt__(self, value: AnyKvKey, /) -> bool:
+        try:
+            return self.kv_key_bytes() < pack_key(value)
+        except TypeError:
+            return NotImplemented
+
+    def __le__(self, value: AnyKvKey, /) -> bool:
+        try:
+            return self.kv_key_bytes() <= pack_key(value)
+        except TypeError:
+            return NotImplemented
+
+    def __gt__(self, value: AnyKvKey, /) -> bool:
+        try:
+            return self.kv_key_bytes() > pack_key(value)
+        except TypeError:
+            return NotImplemented
+
+    def __ge__(self, value: AnyKvKey, /) -> bool:
+        try:
+            return self.kv_key_bytes() >= pack_key(value)
+        except TypeError:
+            return NotImplemented
+
+
+if TYPE_CHECKING:
+    # KvKey isn't actually a tuple subclass at runtime, because we need to store
+    # extra state on each instance to cache the packed representation. The tuple
+    # type does not allow adding extra __slots__. However we do want to use
+    # tuple-like per-element typing, but the only way to do this is to make the
+    # type checker think this is a tuple subtype — Python typing has no way to
+    # type a __getitem__ call as returning the per-item types — tuple is
+    # special-cased.
+
+    # We need ignore[misc] as _KvKeyState order methods like __le__ are broader.
+    class KvKey(_KvKeyState, tuple[Unpack[Pieces]]):  # type: ignore[misc]
+        """
+        A key identifying a value in a Deno KV database.
+
+        KvKey is a tuple of key pieces — str, bytes, int, float or bool. Unlike a
+        plain tuple, KvKey's values are guaranteed to only be valid key values, and
+        int values are not coerced to float for JavaScript comparability when used
+        with [Kv] methods.
+
+        [Kv]: `denokv.kv.Kv`
+        """
+
+        # The Pieces TypeVarTuple cannot be bounded to KvKeyPiece elements, so this
+        # type can hold any element, but  only KvKeyPiece can exist at runtime.
+        def __new__(cls, *pieces: Unpack[Pieces]) -> KvKey[Unpack[Pieces]]: ...
+
+        @overload
+        def __getitem__(self, index: SupportsIndex, /) -> KvKeyPiece: ...
+        @overload
+        def __getitem__(self, index: slice, /) -> KvKey[KvKeyTuple]: ...
+        def __getitem__(
+            self, index: slice | SupportsIndex, /
+        ) -> KvKey | KvKeyPiece: ...
+
+        def __add__(self, value: KvKeyTuple, /) -> KvKey: ...  # type: ignore[override]
+        def __mul__(self, value: SupportsIndex, /) -> KvKey: ...
+        def __rmul__(self, value: SupportsIndex, /) -> KvKey: ...
+
+else:
+
+    @Sequence.register
+    class KvKey(_KvKeyState):
+        """
+        A key identifying a value in a Deno KV database.
+
+        KvKey is a tuple of key pieces — str, bytes, int, float or bool. Unlike a
+        plain tuple, KvKey's values are guaranteed to only be valid key values, and
+        int values are not coerced to float for JavaScript comparability when used
+        with [Kv] methods.
+
+        [Kv]: `denokv.kv.Kv`
+        """
+
+        __slots__ = ()
+
+        def __len__(self) -> int:
+            return len(self._unpacked)
+
+        def __contains__(self, value: object, /) -> bool:
+            return value in self._unpacked
+
+        @overload
+        def __getitem__(self, index: SupportsIndex, /) -> KvKeyPiece: ...
+
+        @overload
+        def __getitem__(self, index: slice, /) -> Self: ...
+
+        def __getitem__(self, index: slice | SupportsIndex, /) -> Self | KvKeyPiece:
+            if isinstance(index, slice):
+                return KvKey(*self._unpacked[index])
+            return self._unpacked[index]
+
+        def __iter__(self) -> Iterator[KvKeyPiece]:
+            return iter(self._unpacked)
+
+        def __reversed__(self) -> Iterator[_T_co]:
+            return reversed(self._unpacked)
+
+        def __add__(self, value: AnyKvKey, /) -> KvKey[KvKeyTuple]:
+            if isinstance(value, KvKey):
+                return KvKey(*self._unpacked, *value._unpacked)
+            if is_kv_key_tuple(value):
+                return KvKey(*self._unpacked, *value)
+            return KvKey(*self._unpacked, *unpack(pack_key(value)))
+
+        def __mul__(self, value: SupportsIndex, /) -> KvKey[KvKeyTuple]:
+            return KvKey(*(self._unpacked * value))
+
+        def __rmul__(self, value: SupportsIndex, /) -> KvKey[KvKeyTuple]:
+            return KvKey(*(self._unpacked * value))
+
+        def count(self, value: Any, /) -> int:
+            return self._unpacked.count(value)
+
+        def index(
+            self,
+            value: object,
+            start: int = 0,
+            stop: int = sys.maxsize,
+            /,
+        ) -> int:
+            return self._unpacked.index(value, start, stop)
 
 
 # Ideally the default parameter of the Pieces KvKeyTuple would make this the
@@ -171,7 +329,7 @@ class _KeyBoundary(Generic[AnyKvKeyT_co]):
 
     def __repr__(self) -> str:
         if isinstance(self.key, KvKey):
-            key = tuple.__repr__(self.key)[1:-1]
+            key = repr(tuple(self.key))[1:-1]
         else:
             key = repr(self.key)
         return f"{type(self).__name__}({key})"

--- a/test/denokv_testing.py
+++ b/test/denokv_testing.py
@@ -36,10 +36,10 @@ from denokv.datapath import parse_protobuf_kv_entry
 from denokv.errors import InvalidCursor
 from denokv.kv import AnyCursorFormat
 from denokv.kv import KvEntry
-from denokv.kv import KvKey
 from denokv.kv import KvU64
 from denokv.kv import ListContext
 from denokv.kv import VersionStamp
+from denokv.kv_keys import KvKey
 from denokv.result import Err
 from denokv.result import Ok
 from denokv.result import Result

--- a/test/test_datapath.py
+++ b/test/test_datapath.py
@@ -47,6 +47,8 @@ from denokv.datapath import ProtocolViolation
 from denokv.datapath import RequestUnsuccessful
 from denokv.datapath import ResponseUnsuccessful
 from denokv.datapath import increment_packed_key
+from denokv.datapath import is_any_kv_key
+from denokv.datapath import is_kv_key_tuple
 from denokv.datapath import pack_key
 from denokv.datapath import pack_key_range
 from denokv.datapath import parse_protobuf_kv_entry
@@ -55,6 +57,7 @@ from denokv.datapath import snapshot_read
 from denokv.kv import KvEntry
 from denokv.kv import KvU64
 from denokv.kv import VersionStamp
+from denokv.kv_keys import KvKey
 from denokv.result import Err
 from denokv.result import Ok
 from test.denokv_testing import MockKvDb
@@ -1009,3 +1012,18 @@ def test_read_range_single(
         assert kve.key == pack_key(key)
         assert kve.value == expected
         assert kve.versionstamp == ver
+
+
+def test_is_kv_key_tuple() -> None:
+    assert is_kv_key_tuple(("a", 1, 1.0, True, b"b"))
+    assert is_kv_key_tuple(cast(object, ("a", 1, 1.0, True, b"b")))
+    assert not is_kv_key_tuple(((),))
+    assert is_kv_key_tuple(KvKey("x"))
+
+
+def test_is_any_kv_key() -> None:
+    assert is_any_kv_key(KvKey("x"))
+    assert is_any_kv_key(cast(object, KvKey("x")))
+    assert is_any_kv_key(("a", 1, 1.0, True, b"b"))
+    assert not is_any_kv_key([])
+    assert not is_any_kv_key(((),))

--- a/test/test_datapath.py
+++ b/test/test_datapath.py
@@ -26,6 +26,7 @@ from typing_extensions import TypeAlias
 from v8serialize import Decoder
 from yarl import URL
 
+from denokv import datapath
 from denokv._datapath_pb2 import KvEntry as ProtobufKvEntry
 from denokv._datapath_pb2 import ReadRange
 from denokv._datapath_pb2 import ReadRangeOutput
@@ -779,6 +780,13 @@ def test_pack_key() -> None:
         (float, 2.0),
         (bool, True),
     )
+
+
+def test_pack_key_cache() -> None:
+    for i in range(datapath._PACK_KEY_CACHE_LIMIT * 2):
+        assert unpack(pack_key(("foo", i))) == ("foo", i)
+
+    assert len(datapath._PACK_KEY_CACHE) == datapath._PACK_KEY_CACHE_LIMIT
 
 
 def test_pack_key__rejects_unsupported_types() -> None:

--- a/test/test_datapath.py
+++ b/test/test_datapath.py
@@ -627,7 +627,7 @@ async def test_snapshot_read__reads_expected_values(
         for res_range in result.value.ranges
     ]
     expected_result_ranges = [
-        [KvEntry(key, value, versionstamp=ver) for (key, value) in entries]
+        [KvEntry(KvKey(*key), value, versionstamp=ver) for (key, value) in entries]
         for entries in result_ranges
     ]
     assert actual_result_ranges == expected_result_ranges
@@ -644,7 +644,7 @@ async def test_snapshot_read__reads_expected_values(
                 value=b"foo",
             ),
             KvEntry(
-                key=("a",),
+                key=KvKey("a"),
                 value=b"foo",
                 versionstamp=VersionStamp("00000000000000000001"),
             ),
@@ -657,7 +657,7 @@ async def test_snapshot_read__reads_expected_values(
                 value=struct.pack("<Q", 15043183363527981566),
             ),
             KvEntry(
-                key=("a", 42, 1.0, True, b"b"),
+                key=KvKey("a", 42, 1.0, True, b"b"),
                 value=KvU64(15043183363527981566),
                 versionstamp=VersionStamp("000000000000000f0001"),
             ),
@@ -670,7 +670,7 @@ async def test_snapshot_read__reads_expected_values(
                 value=v8serialize.dumps("foo"),
             ),
             KvEntry(
-                key=("a",),
+                key=KvKey("a"),
                 value="foo",
                 versionstamp=VersionStamp("000000000000000f0001"),
             ),
@@ -1018,7 +1018,7 @@ def test_is_kv_key_tuple() -> None:
     assert is_kv_key_tuple(("a", 1, 1.0, True, b"b"))
     assert is_kv_key_tuple(cast(object, ("a", 1, 1.0, True, b"b")))
     assert not is_kv_key_tuple(((),))
-    assert is_kv_key_tuple(KvKey("x"))
+    assert not is_kv_key_tuple(KvKey("x"))
 
 
 def test_is_any_kv_key() -> None:

--- a/test/test_kv.py
+++ b/test/test_kv.py
@@ -67,6 +67,7 @@ from denokv.kv import KvU64
 from denokv.kv import VersionStamp
 from denokv.kv import normalize_key
 from denokv.kv import open_kv
+from denokv.kv_keys import KvKey
 from denokv.result import Err
 from denokv.result import Ok
 from denokv.result import Result
@@ -954,7 +955,7 @@ async def test_Kv_list__retries_retryable_snapshot_read_errors(
         results.append((kv_entry.key, kv_entry.value, kv_entry.versionstamp))
 
     assert results == [
-        (("a", x), f"x{x}".encode(), VersionStamp(1)) for x in range(1, 5)
+        (KvKey("a", x), f"x{x}".encode(), VersionStamp(1)) for x in range(1, 5)
     ]
     assert len(auth_fn.mock_calls) == 7
 

--- a/test/test_kv_keys__kvkey.py
+++ b/test/test_kv_keys__kvkey.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 from typing import Sequence
+from typing import cast
 
 import pytest
 from fdb.tuple import pack
@@ -12,8 +13,134 @@ from denokv.datapath import AnyKvKey
 from denokv.datapath import KvKeyEncodable
 from denokv.datapath import KvKeyPiece
 from denokv.datapath import KvKeyTuple
-from denokv.kv_keys import DefaultKvKey
+from denokv.datapath import pack_key
 from denokv.kv_keys import KvKey
+
+
+def test_instances_do_not_define_dict() -> None:
+    k = KvKey()
+    with pytest.raises(AttributeError):
+        print(k.__dict__)
+
+
+def test_instances_are_KvKeyEncodable() -> None:
+    key = cast(object, KvKey())
+    assert isinstance(key, KvKeyEncodable)
+    assert key.kv_key_bytes() == b""
+
+
+def test_instances_are_Sequences() -> None:
+    key = cast(object, KvKey(1, 2, 3))
+    assert isinstance(key, Sequence)
+    assert list(key) == [1, 2, 3]
+
+
+@pytest.mark.parametrize("pieces", [(), ("a",), ("a", 1, 2)])
+def test_KvKey(pieces: tuple[KvKeyPiece, ...]) -> None:
+    key = KvKey(*pieces)
+    # KvKey is not actually a tuple subclass at runtime
+    assert not isinstance(key, tuple)
+    assert type(key) is KvKey
+    assert tuple(key) == pieces
+
+
+def test_wrap_tuple_keys() -> None:
+    class CustomKey(KvKeyEncodable):
+        def kv_key_bytes(self) -> bytes:
+            return b""
+
+    assert KvKey.wrap_tuple_keys(("a", 1)) == KvKey("a", 1)
+    custom = CustomKey()
+    assert KvKey.wrap_tuple_keys(custom) is custom
+
+
+def test_eq_hash() -> None:
+    a1, a2 = KvKey("foo", 1), KvKey("foo", 1)
+    b1, b2 = KvKey("foo", 2), KvKey("foo", 2)
+
+    assert a1 == a2
+    assert hash(a1) == hash(a2)
+    assert b1 == b2
+    assert hash(b1) == hash(b2)
+    assert a1 != b2
+    assert hash(a1) != hash(b2)
+
+    # not equal to plain tuples — Python compares 1 and 1.0 the same, which
+    # makes plain tuples not compare consistently with packed representation.
+    assert a1 != tuple(a1)
+    assert hash(a1) != hash(tuple(a1))
+
+
+def test_kv_key_bytes() -> None:
+    assert KvKey("foo", 1).kv_key_bytes() == pack_key(("foo", 1))
+
+
+@pytest.mark.parametrize("l", [-1, 0, 1, -1.0, 0.0, 1.0, "a", "b"])
+@pytest.mark.parametrize("r", [-1, 0, 1, -1.0, 0.0, 1.0, "a", "b"])
+def test_order_comparisons(l: KvKeyPiece, r: KvKeyPiece) -> None:  # noqa: E741
+    lk, rk = (l,), (r,)
+    plk, prk = pack_key(lk), pack_key(rk)
+
+    kvkeyl, kvkr = KvKey(l), KvKey(r)
+
+    assert (kvkeyl < kvkr) is (plk < prk)
+    assert (kvkeyl <= kvkr) is (plk <= prk)
+    assert (kvkeyl >= kvkr) is (plk >= prk)
+    assert (kvkeyl > kvkr) is (plk > prk)
+
+
+def test_tuple_methods() -> None:
+    key = KvKey("a", "b", "c")
+    assert len(key) == 3
+    assert "b" in key and "d" not in key
+    assert key[0] == "a"
+    assert key[1:] == KvKey("b", "c")
+    assert list(iter(key)) == ["a", "b", "c"]
+    assert list(reversed(key)) == ["c", "b", "a"]
+    assert key + KvKey("d", "e") == KvKey("a", "b", "c", "d", "e")
+    assert key + ("d", "e") == KvKey("a", "b", "c", "d", "e")
+    assert key * 2 == KvKey("a", "b", "c", "a", "b", "c")
+    assert 2 * key == KvKey("a", "b", "c", "a", "b", "c")
+    assert (key * 3).count("b") == 3
+    assert key.index("b") == 1
+
+
+def test_types() -> None:
+    _k1: KvKey[Literal["foo"], Literal[1]] = KvKey("foo", 1)
+    _k2: KvKey[str, int] = KvKey("foo", 1)
+
+    # expected errors
+    _k3: KvKey[str, int] = KvKey(1, "a")  # type: ignore[arg-type]
+
+    k: KvKey[str, int] = KvKey("a", 1)
+    _k_item1: str = k[0]
+    # expected error
+    _k_item2: str = k[1]  # type: ignore[assignment]
+
+    _k_slice1: KvKey = KvKey("a", 1, "b", 2)
+    # expected error: cannot currently type custom tuple slice method
+    _k_slice2: KvKey[str, int] = _k_slice1[2:]  # type: ignore[assignment]
+    _k_slice3: KvKey = _k_slice1[2:]
+
+    a: str
+    b: int
+    a, b = k
+
+    # expected error:
+    b, a = k  # type: ignore[assignment]
+
+    # AFAIK it's not possible to type custom tuple concatenation. tuple's own
+    # add method seems to be special-cased by type checkers.
+    # https://github.com/python/typing/discussions/1439
+    _t1: tuple[str, int, str, int] = ("a", 1) + ("a", 1)
+    _k4: KvKey[tuple[KvKeyPiece, ...]] = KvKey("a", 1) + KvKey("a", 1)
+    _k5: KvKey = KvKey("a", 1) + KvKey("a", 1)
+
+    _t2: tuple[str, int, str, int] = ("a", 1) * 2
+    _k6: KvKey[tuple[KvKeyPiece, ...]] = KvKey("a", 1) * 2
+    _k7: KvKey = KvKey("a", 1) * 2
+    _k8: KvKey[tuple[KvKeyPiece, ...]] = 2 * KvKey("a", 1)
+    _k9: KvKey = 2 * KvKey("a", 1)
 
 
 def test_kvkey__generic_tuple_params() -> None:
@@ -54,16 +181,6 @@ def test_from_kv_key_bytes() -> None:
     assert KvKey("foo", 42) == KvKey.from_kv_key_bytes(pack(("foo", 42)))
 
 
-def test_kv_key_bytes() -> None:
-    assert KvKey("foo", b"bar", 1, 2.0, True).kv_key_bytes() == pack(
-        (("foo", b"bar", 1, 2.0, True))
-    )
-
-
-def test_is_KvKeyEncodable() -> None:
-    assert isinstance(KvKey(), KvKeyEncodable)
-
-
 def test_unknown_pieces() -> None:
     def get_pieces() -> Sequence[KvKeyPiece]:
         return ["foo", b"bar", 1, 2.0, True]
@@ -89,10 +206,3 @@ def test_unknown_pieces() -> None:
     use_key(key2)
     use_key_encodable(key2)
     use_key_tuple(key2)
-
-
-def test_wrap_tuple_keys() -> None:
-    key: DefaultKvKey = KvKey.wrap_tuple_keys(("a", 2, True))
-    assert isinstance(key, KvKey)
-    assert key == KvKey("a", 2, True)
-    assert key == ("a", 2, True)

--- a/test/test_kv_keys__kvkey.py
+++ b/test/test_kv_keys__kvkey.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import weakref
 from typing import Literal
 from typing import Sequence
 from typing import cast
@@ -103,6 +104,14 @@ def test_tuple_methods() -> None:
     assert 2 * key == KvKey("a", "b", "c", "a", "b", "c")
     assert (key * 3).count("b") == 3
     assert key.index("b") == 1
+
+
+def test_weakref() -> None:
+    key = KvKey("foo")
+    r = weakref.ref(key)
+    assert r() is key
+    del key
+    assert r() is None
 
 
 def test_types() -> None:

--- a/test/test_kv_keys__kvkey.py
+++ b/test/test_kv_keys__kvkey.py
@@ -12,10 +12,8 @@ from denokv.datapath import AnyKvKey
 from denokv.datapath import KvKeyEncodable
 from denokv.datapath import KvKeyPiece
 from denokv.datapath import KvKeyTuple
-
-# from denokv.kv import DefaultKvKey
-from denokv.kv import DefaultKvKey
-from denokv.kv import KvKey
+from denokv.kv_keys import DefaultKvKey
+from denokv.kv_keys import KvKey
 
 
 def test_kvkey__generic_tuple_params() -> None:

--- a/test/test_kv_keys__kvkeyrange.py
+++ b/test/test_kv_keys__kvkeyrange.py
@@ -1,0 +1,194 @@
+from typing import Literal
+from typing import cast
+
+import pytest
+
+from denokv.kv_keys import Exclude
+from denokv.kv_keys import Include
+from denokv.kv_keys import IncludeAll
+from denokv.kv_keys import IncludePrefix
+from denokv.kv_keys import KvKey
+from denokv.kv_keys import KvKeyRange
+from denokv.kv_keys import StartBoundary
+from denokv.kv_keys import StopBoundary
+
+
+def test_types() -> None:
+    _bound1: Include[KvKey[Literal["a"], Literal[1]]] = Include(KvKey("a", 1))
+    _bound2: Include[KvKey[Literal["a"], Literal[1]]] = Include("a", 1)
+    _bound3: Exclude[KvKey[Literal["a"], Literal[1]]] = Exclude(KvKey("a", 1))
+    _bound4: Exclude[KvKey[Literal["a"], Literal[10]]] = Exclude("a", 10)
+    _bound5: IncludePrefix[KvKey[Literal["a"], Literal[1]]] = IncludePrefix(
+        KvKey("a", 1)
+    )
+    _bound6: IncludePrefix[KvKey[Literal["a"], Literal[1]]] = IncludePrefix("a", 1)
+
+    start_boundary = cast(StartBoundary, IncludeAll())
+    stop_boundary = cast(StopBoundary, IncludeAll())
+
+    _range_unspecified: KvKeyRange = KvKeyRange(
+        start=start_boundary, stop=stop_boundary
+    )
+
+    _range_open: KvKeyRange[IncludeAll, IncludeAll] = KvKeyRange()
+    _range_open = IncludeAll.range()
+    _range_open = IncludeAll().range()
+    _range_open = KvKeyRange(IncludeAll())
+    _range_open = KvKeyRange(stop=IncludeAll())
+
+    _range_include_exclude1: KvKeyRange[
+        Include[KvKey[Literal["a"], Literal[1]]],
+        Exclude[KvKey[Literal["a"], Literal[10]]],
+    ] = KvKeyRange(_bound1, _bound4)
+
+    _range_include_exclude2: KvKeyRange[
+        Include[KvKey[Literal["a"], Literal[1]]],
+        Exclude[KvKey[Literal["a"], Literal[10]]],
+    ] = KvKeyRange(Include("a", 1), Exclude("a", 10))
+
+    _range_exclude_includeprefix1: KvKeyRange[
+        Exclude[KvKey[str, int]], IncludePrefix[KvKey[str, int]]
+    ] = IncludePrefix("a", 10).range_start(Exclude("a", 0))
+
+    _range_exclude_includeprefix2: KvKeyRange[
+        Exclude[KvKey[str, int]], IncludePrefix[KvKey[str, int]]
+    ] = _bound6.range_start(Exclude("a", 0))
+
+
+def test_KvKey__range() -> None:
+    assert KvKey("a", 1).range() == KvKeyRange(Include("a", 1), IncludePrefix("a", 1))
+    assert KvKey("a", 10).range_start(Include("a", 1)) == KvKeyRange(
+        Include("a", 1), Exclude("a", 10)
+    )
+    assert KvKey("a", 1).range_stop(Exclude("a", 10)) == KvKeyRange(
+        Include("a", 1), Exclude("a", 10)
+    )
+
+
+def test_Include() -> None:
+    assert Include("a", 1) == Include(KvKey("a", 1))
+    assert Include(("a", 1)) == Include(("a", 1))
+
+    assert ("a", 1) in Include("a", 1).range()
+    assert Include("a", 1).range() == KvKeyRange(Include(("a", 1)), Include(("a", 1)))
+    assert Include("a", 1).range_stop(Exclude("a", 10)) == KvKeyRange(
+        Include(("a", 1)), Exclude(("a", 10))
+    )
+    assert Include("a", 9).range_start(Include("a", 1)) == KvKeyRange(
+        Include(("a", 1)), Include(("a", 9))
+    )
+
+
+def test_Exclude() -> None:
+    assert Exclude("a", 1) == Exclude(KvKey("a", 1))
+    assert Exclude(("a", 1)) == Exclude(("a", 1))
+
+    assert ("a", 1) not in Exclude("a", 1).range()
+    assert Exclude("a", 1).range() == KvKeyRange(Exclude(("a", 1)), Exclude(("a", 1)))
+    assert Exclude("a", 1).range_stop(Exclude("a", 10)) == KvKeyRange(
+        Exclude(("a", 1)), Exclude(("a", 10))
+    )
+    assert Exclude("a", 9).range_start(Exclude("a", 1)) == KvKeyRange(
+        Exclude(("a", 1)), Exclude(("a", 9))
+    )
+
+
+def test_IncludeAll() -> None:
+    a, b = IncludeAll(), IncludeAll()
+    assert a is b, "IncludeAll() returns a singleton instance"
+
+    assert ("a", 1) in IncludeAll().range()
+    assert ("a", 1) in IncludeAll.range()
+    assert IncludeAll.range() == KvKeyRange(IncludeAll(), IncludeAll())
+    assert IncludeAll().range_stop(Exclude("a", 10)) == KvKeyRange(
+        IncludeAll(), Exclude(("a", 10))
+    )
+    assert IncludeAll().range_start(Exclude("a", 1)) == KvKeyRange(
+        Exclude(("a", 1)), IncludeAll()
+    )
+
+
+def test_IncludePrefix() -> None:
+    assert IncludePrefix("a", 1) == IncludePrefix(KvKey("a", 1))
+    assert IncludePrefix(("a", 1)) == IncludePrefix(("a", 1))
+
+    assert IncludePrefix("a", 1).range() == KvKeyRange(
+        Include(("a", 1)), IncludePrefix(("a", 1))
+    )
+    assert IncludePrefix("a", 1).range_stop(Exclude("a", 10)) == KvKeyRange(
+        Include(("a", 1)), Exclude(("a", 10))
+    )
+    assert IncludePrefix("a", 9).range_start(Include("a", 1)) == KvKeyRange(
+        Include(("a", 1)), IncludePrefix(("a", 9))
+    )
+
+
+def test_KvKeyRange() -> None:
+    assert KvKeyRange() == KvKeyRange(IncludeAll(), IncludeAll())
+    assert KvKeyRange(Include("a", 1)) == KvKeyRange(Include("a", 1), IncludeAll())
+    assert KvKeyRange(Include("a", 1), Exclude("a", 10)) == KvKeyRange(
+        Include("a", 1), Exclude("a", 10)
+    )
+    # IncludePrefix as start is not allowed by type, but normalised to Include()
+    # at runtime.
+    assert KvKeyRange(IncludePrefix("a", 1), IncludePrefix("a", 1)) == KvKeyRange(  # type: ignore[type-var]
+        Include("a", 1), IncludePrefix("a", 1)
+    )
+
+
+@pytest.mark.parametrize(
+    "start, key, key_included",
+    [
+        (IncludeAll(), KvKey("a"), True),
+        (Include("b", 1), KvKey("a"), False),
+        (Include("b", 1), KvKey("b", 0), False),
+        (Include("b", 1), KvKey("b"), False),
+        (Include("b", 1), KvKey("b", 1), True),
+        (Include("b", 1), KvKey("b", 1, 2, 3), True),
+        (Include("b", 1), KvKey("b", 2), True),
+        (Exclude("b", 1), KvKey("a"), False),
+        (Exclude("b", 1), KvKey("b", 0), False),
+        (Exclude("b", 1), KvKey("b"), False),
+        (Exclude("b", 1), KvKey("b", 1), False),
+        (Include("b", 1), KvKey("b", 1, 2, 3), True),
+        (Exclude("b", 1), KvKey("b", 2), True),
+    ],
+)
+def test_contains__start(start: StartBoundary, key: KvKey, key_included: bool) -> None:
+    key_range = KvKeyRange(start, IncludeAll())
+
+    assert (key in key_range) == key_included
+
+
+@pytest.mark.parametrize(
+    "stop, key, key_included",
+    [
+        (IncludeAll(), KvKey("z"), True),
+        (Include("b", 10), KvKey("z"), False),
+        (Include("b", 10), KvKey("b", 11), False),
+        (Exclude("b", 10), KvKey("b", 10, 1, 2), False),
+        (Include("b", 10), KvKey("b", 10), True),
+        (Include("b", 10), KvKey("b", 9, 1, 2), True),
+        (Include("b", 10), KvKey("b", 9), True),
+        (Exclude("b", 10), KvKey("z"), False),
+        (Exclude("b", 10), KvKey("b", 11), False),
+        (Exclude("b", 10), KvKey("b", 10, 1, 2), False),
+        (Exclude("b", 10), KvKey("b", 10), False),
+        (Exclude("b", 10), KvKey("b", 9, 1, 2), True),
+        (Exclude("b", 10), KvKey("b", 9), True),
+        (IncludePrefix("b", 10), KvKey("z"), False),
+        (IncludePrefix("b", 10), KvKey("b", 11), False),
+        (IncludePrefix("b", 10), KvKey("b", 10, 1, 2), True),
+        (IncludePrefix("b", 10), KvKey("b", 10), True),
+        (IncludePrefix("b", 10), KvKey("b", 9, 1, 2), True),
+        (IncludePrefix("b", 10), KvKey("b", 9), True),
+    ],
+)
+def test_contains__stop(
+    stop: StopBoundary,
+    key: KvKey,
+    key_included: bool,
+) -> None:
+    key_range = KvKeyRange(IncludeAll(), stop)
+
+    assert (key in key_range) == key_included


### PR DESCRIPTION
This PR aims to make KvKey the main type to represent key values. Plain tuples have the problem that they don't compare the same as encoded keys do, because encoded keys distinguish float from int values, but Python doesn't.

> KvKey now has equality and order comparison behaviour that follows the
packed key representation. (Plain Python tuples compare differently
to packed keys, because int and float compare/hash the same as Python
values, but not when packed.)
>
> KvKey now caches the packed representation the first time it's
calculated, so each instance only packs once. We use the packed
representation in various other methods now.
>
> The tuple methods and type annotations are also more accurate, as they
are overridden to return KvKey instances, not plain tuples. It's no
longer an actual tuple subclass, rather it's a regular class that is
annotated to pretend to be a tuple subclass in order to use some of the
special tuple type handling.

It also introduces the KvKeyRange type to represent ranges of keys. The datapath protocol operations use ranges of keys rather than specific keys, and it's useful to have access to this concept at a higher level than the datapath module's low-level functions for interacting with the protocol. For example, rather than using `kv.list()` to select keys in a range, using KvKeyRange we can provide a `get()`-type method to fetch a single set of values in a range, without going through the async iterator interface.

I've extracted these changes from a the larger `wip-read-groups` branch which has too many different things going on.