### PR TITLE
Fix _pycompat.typing.assert_type()

### DIFF
--- a/src/denokv/_pycompat/typing.py
+++ b/src/denokv/_pycompat/typing.py
@@ -97,8 +97,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias as TypeAlias
     from typing_extensions import TypeGuard as TypeGuard
     from typing_extensions import TypeIs as TypeIs
-    from typing_extensions import TypeVarTuple as TypeVarTuple
-    from typing_extensions import Unpack as Unpack
 else:
     Never = "Never"
     ParamSpec = "ParamSpec"
@@ -106,8 +104,6 @@ else:
     TypeAlias = "TypeAlias"
     TypeGuard = "TypeGuard"
     TypeIs = "TypeIs"
-    # TypeVarTuple = "TypeVarTuple"
-    # Unpack = "Unpack"
 
 if TYPE_CHECKING:
     from typing_extensions import TypeVar as TypeVar

--- a/src/denokv/_pycompat/typing.py
+++ b/src/denokv/_pycompat/typing.py
@@ -177,4 +177,4 @@ if TYPE_CHECKING:
 else:
 
     def assert_type(val: _T, typ: Any, /) -> _T:
-        pass
+        return val


### PR DESCRIPTION
It was returning None at runtime, which is incorrect.